### PR TITLE
episodes

### DIFF
--- a/README.org
+++ b/README.org
@@ -29,10 +29,11 @@ not really sure about this one, frankly - =StateFlow=​s seem to behave better 
 I'm imagining making the thumbnail animate from the view podcasts screen to the podcast details screen
 ** TODO Move =compose= calls to their respective blocks
 Following the advice detailed [[https://developer.android.com/guide/navigation/design/type-safety#navigate-destination][here]]
-** TODO read up on some things [0/2]
-*** TODO Room basics
+** TODO parse =pubDate= to sort by release date
+** DONE read up on some things [0/0]
+*** DONE Room basics
 [[https://developer.android.com/training/data-storage/room]]
-*** TODO Migrating Room databases
+*** DONE Migrating Room databases
 [[https://developer.android.com/training/data-storage/room/migrating-db-versions]]
 ** TODO check out the example podcast app
 *** link

--- a/README.org
+++ b/README.org
@@ -12,7 +12,9 @@ still very much a work in progress
 ** TODO improve xml parsing code
 *** TODO make it slightly more declarative, build up a mini-dsl
 *** TODO make it more fault tolerant
-** TODO parse xml to list episodes
+don't throw, at least
+**** TODO handle faults at higher levels too
+** DONE parse xml to list episodes
 ** TODO display images for podcasts
 *** TODO parse from xml
 *** TODO download
@@ -27,9 +29,19 @@ not really sure about this one, frankly - =StateFlow=​s seem to behave better 
 *** TODO android/integration tests
 ** TODO try shared element transition
 I'm imagining making the thumbnail animate from the view podcasts screen to the podcast details screen
-** TODO Move =compose= calls to their respective blocks
+** TODO Make screens a little better encapsulated and type-safe
+*** TODO Move =compose= calls to their respective blocks
 Following the advice detailed [[https://developer.android.com/guide/navigation/design/type-safety#navigate-destination][here]]
+*** TODO Make extension methods for navigating to particular screens
 ** TODO parse =pubDate= to sort by release date
+** TODO make podcasts unique in their url
+make sure that someone can't add the same podcast twice
+** TODO make episodes detail screen
+** TODO make things pretty [0/3]
+*** TODO spacing
+*** TODO font sizes
+*** TODO coloring
+** TODO make a way of showing a details screen for a podcast that hasn't been saved yet
 ** DONE read up on some things [0/0]
 *** DONE Room basics
 [[https://developer.android.com/training/data-storage/room]]

--- a/app/schemas/four.credits.podcatch.data.persistence.PodcastDatabase/2.json
+++ b/app/schemas/four.credits.podcatch.data.persistence.PodcastDatabase/2.json
@@ -1,0 +1,118 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 2,
+    "identityHash": "bf3d102c2ed16080af97e1ded9a0d361",
+    "entities": [
+      {
+        "tableName": "Podcast",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `title` TEXT NOT NULL, `description` TEXT NOT NULL, `link` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "link",
+            "columnName": "link",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "Episode",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`title` TEXT NOT NULL, `description` TEXT NOT NULL, `link` TEXT NOT NULL, `podcastId` INTEGER NOT NULL, `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, FOREIGN KEY(`podcastId`) REFERENCES `Podcast`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "link",
+            "columnName": "link",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "podcastId",
+            "columnName": "podcastId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_Episode_podcastId",
+            "unique": false,
+            "columnNames": [
+              "podcastId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_Episode_podcastId` ON `${TABLE_NAME}` (`podcastId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "Podcast",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "podcastId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'bf3d102c2ed16080af97e1ded9a0d361')"
+    ]
+  }
+}

--- a/app/schemas/four.credits.podcatch.data.persistence.PodcastDatabase/3.json
+++ b/app/schemas/four.credits.podcatch.data.persistence.PodcastDatabase/3.json
@@ -1,0 +1,118 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 3,
+    "identityHash": "ce30699e62d48a06b7dfb3a9ddd4078c",
+    "entities": [
+      {
+        "tableName": "Podcast",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `title` TEXT NOT NULL, `description` TEXT NOT NULL, `link` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "link",
+            "columnName": "link",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "Episode",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`title` TEXT NOT NULL, `description` TEXT NOT NULL, `link` TEXT NOT NULL, `podcastId` INTEGER NOT NULL, `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, FOREIGN KEY(`podcastId`) REFERENCES `Podcast`(`id`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "link",
+            "columnName": "link",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "podcastId",
+            "columnName": "podcastId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_Episode_podcastId",
+            "unique": false,
+            "columnNames": [
+              "podcastId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_Episode_podcastId` ON `${TABLE_NAME}` (`podcastId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "Podcast",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "podcastId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'ce30699e62d48a06b7dfb3a9ddd4078c')"
+    ]
+  }
+}

--- a/app/src/androidTest/java/four/credits/podcatch/data/PodcastParsingTests.kt
+++ b/app/src/androidTest/java/four/credits/podcatch/data/PodcastParsingTests.kt
@@ -1,5 +1,6 @@
 package four.credits.podcatch.data
 
+import four.credits.podcatch.domain.Episode
 import four.credits.podcatch.domain.Podcast
 import org.junit.Test
 import org.junit.Assert.*
@@ -40,10 +41,63 @@ class PodcastParsingTests {
             </rss>
         """.trimIndent().byteInputStream()
         val result = parsePodcast(input, "https://example.com/top-level")
-        // TODO: make tests for feeds with only one channel
         val expected = listOf(
-            Podcast("Podcast 1", "Foo", "https://example.com/top-level", listOf()),
-            Podcast("Podcast 2", "Bar", "https://example.com/top-level", listOf())
+            Podcast(
+                "Podcast 1",
+                "Foo",
+                "https://example.com/top-level",
+                listOf()
+            ),
+            Podcast(
+                "Podcast 2",
+                "Bar",
+                "https://example.com/top-level",
+                listOf()
+            )
+        )
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun correctlyParsesChannelWithEpisodes() {
+        val input = """
+            <rss>
+              <channel>
+                <title>Podcast 1</title>
+                <link>https://example.com/1</link>
+                <description>Foo</description>
+                <item>
+                  <title>Episode 1</title>
+                  <link>https://example.com/1/1</link>
+                  <description>the description of the episode</description>
+                </item>
+                <item>
+                  <title>Episode 2</title>
+                  <link>https://example.com/1/2</link>
+                  <description>the second description</description>
+                </item>
+              </channel>
+            </rss>
+        """.trimIndent().byteInputStream()
+        val result = parsePodcast(input, "https://example.com/top-level")
+        val expected = listOf(
+            Podcast(
+                "Podcast 1",
+                "Foo",
+                "https://example.com/top-level",
+                listOf(
+                    Episode(
+                        title = "Episode 1",
+                        link = "https://example.com/1/1",
+                        description = "the description of the episode",
+                    ),
+                    Episode(
+                        title = "Episode 2",
+                        link = "https://example.com/1/2",
+                        description = "the second description",
+                    )
+                )
+            ),
         )
         assertEquals(expected, result)
     }

--- a/app/src/androidTest/java/four/credits/podcatch/data/PodcastParsingTests.kt
+++ b/app/src/androidTest/java/four/credits/podcatch/data/PodcastParsingTests.kt
@@ -6,7 +6,7 @@ import org.junit.Assert.*
 
 class PodcastParsingTests {
     @Test
-    fun correctlyParsesFullFeed() {
+    fun correctlyParsesMultipleChannels() {
         val input = """
             <rss>
               <channel>
@@ -22,9 +22,11 @@ class PodcastParsingTests {
             </rss>
         """.trimIndent().byteInputStream()
         val result = parsePodcast(input, "https://example.com/top-level")
+        // TODO: make tests for feeds with non-zero episodes
+        // TODO: make tests for feeds with only one channel
         val expected = listOf(
-            Podcast("Podcast 1", "Foo", "https://example.com/top-level"),
-            Podcast("Podcast 2", "Bar", "https://example.com/top-level")
+            Podcast("Podcast 1", "Foo", "https://example.com/top-level", listOf()),
+            Podcast("Podcast 2", "Bar", "https://example.com/top-level", listOf())
         )
         assertEquals(expected, result)
     }

--- a/app/src/androidTest/java/four/credits/podcatch/data/PodcastParsingTests.kt
+++ b/app/src/androidTest/java/four/credits/podcatch/data/PodcastParsingTests.kt
@@ -6,6 +6,24 @@ import org.junit.Assert.*
 
 class PodcastParsingTests {
     @Test
+    fun correctlyParsesSingleChannel() {
+        val input = """
+            <rss>
+              <channel>
+                <title>Podcast 1</title>
+                <link>https://example.com/1</link>
+                <description>Foo</description>
+              </channel>
+            </rss>
+        """.trimIndent().byteInputStream()
+        val result = parsePodcast(input, "https://example.com/top-level")
+        val expected = listOf(
+            Podcast("Podcast 1", "Foo", "https://example.com/top-level", listOf()),
+        )
+        assertEquals(expected, result)
+    }
+
+    @Test
     fun correctlyParsesMultipleChannels() {
         val input = """
             <rss>
@@ -22,7 +40,6 @@ class PodcastParsingTests {
             </rss>
         """.trimIndent().byteInputStream()
         val result = parsePodcast(input, "https://example.com/top-level")
-        // TODO: make tests for feeds with non-zero episodes
         // TODO: make tests for feeds with only one channel
         val expected = listOf(
             Podcast("Podcast 1", "Foo", "https://example.com/top-level", listOf()),

--- a/app/src/main/java/four/credits/podcatch/PodcatchApplication.kt
+++ b/app/src/main/java/four/credits/podcatch/PodcatchApplication.kt
@@ -16,6 +16,6 @@ class PodcatchApplication : Application() {
     }
 
     val podcastRepository: PodcastRepository by lazy {
-        InternetPodcastRepository(database.dao)
+        InternetPodcastRepository(database.podcastDao)
     }
 }

--- a/app/src/main/java/four/credits/podcatch/PodcatchApplication.kt
+++ b/app/src/main/java/four/credits/podcatch/PodcatchApplication.kt
@@ -16,6 +16,6 @@ class PodcatchApplication : Application() {
     }
 
     val podcastRepository: PodcastRepository by lazy {
-        InternetPodcastRepository(database.podcastDao)
+        InternetPodcastRepository(database.podcastDao, database.episodeDao)
     }
 }

--- a/app/src/main/java/four/credits/podcatch/data/InternetPodcastRepository.kt
+++ b/app/src/main/java/four/credits/podcatch/data/InternetPodcastRepository.kt
@@ -26,11 +26,10 @@ class InternetPodcastRepository(
         }
 
     override suspend fun addPodcast(podcast: Podcast) {
-        // TODO: find a way to do this in a transaction
-        podcastDao.upsertPodcast(podcast.toDatabaseModel())
-        podcast.episodes.forEach {
-            episodeDao.upsertEpisode(it.toDatabaseModel())
-        }
+        val podcastId = podcastDao.insertPodcast(podcast.toDatabaseModel())
+        episodeDao.upsertEpisode(podcast.episodes.map { episode ->
+            episode.toDatabaseModel().copy(podcastId = podcastId)
+        })
     }
 
     override suspend fun deletePodcast(podcast: Podcast) =

--- a/app/src/main/java/four/credits/podcatch/data/InternetPodcastRepository.kt
+++ b/app/src/main/java/four/credits/podcatch/data/InternetPodcastRepository.kt
@@ -46,8 +46,6 @@ class InternetPodcastRepository(
             podcastDao.getPodcastById(id),
             episodeDao.getEpisodesByPodcastId(id)
         ) { podcast, episodes ->
-            podcast
-                ?.toDomainModel()
-                ?.copy(episodes = episodes.map { it.toDomainModel() })
+            podcast?.toDomainModel(episodes.map { it.toDomainModel() })
         }
 }

--- a/app/src/main/java/four/credits/podcatch/data/InternetPodcastRepository.kt
+++ b/app/src/main/java/four/credits/podcatch/data/InternetPodcastRepository.kt
@@ -40,6 +40,7 @@ class InternetPodcastRepository(
         .map { podcasts -> podcasts.map { it.toDomainModel() } }
 
     // TODO: make a better way of querying this
+    //  (should surely be able to be one query)
     override fun getPodcastById(id: Long): Flow<Podcast?> =
         combine(
             podcastDao.getPodcastById(id),

--- a/app/src/main/java/four/credits/podcatch/data/InternetPodcastRepository.kt
+++ b/app/src/main/java/four/credits/podcatch/data/InternetPodcastRepository.kt
@@ -12,7 +12,7 @@ import kotlinx.coroutines.withContext
 import java.net.URL
 
 class InternetPodcastRepository(
-    private val dao: PodcastDao,
+    private val podcastDao: PodcastDao,
 ) : PodcastRepository {
     override suspend fun getPodcast(url: String): Podcast =
         withContext(Dispatchers.IO) {
@@ -20,15 +20,16 @@ class InternetPodcastRepository(
         }
 
     override suspend fun addPodcast(podcast: Podcast) =
-        dao.upsertPodcast(podcast.toDatabaseModel())
+        podcastDao.upsertPodcast(podcast.toDatabaseModel())
 
     override suspend fun deletePodcast(podcast: Podcast) =
-        dao.deletePodcast(podcast.toDatabaseModel())
+        podcastDao.deletePodcast(podcast.toDatabaseModel())
 
-    override fun allPodcasts(): Flow<List<Podcast>> = dao
+    override fun allPodcasts(): Flow<List<Podcast>> = podcastDao
         .getPodcastsOrderedByTitle()
         .map { podcasts -> podcasts.map { it.toDomainModel() } }
 
-    override fun getPodcastById(id: Long): Flow<Podcast?> =
-        dao.getPodcastById(id).map { podcast -> podcast?.toDomainModel() }
+    override fun getPodcastById(id: Long): Flow<Podcast?> = podcastDao
+        .getPodcastById(id)
+        .map { podcast -> podcast?.toDomainModel() }
 }

--- a/app/src/main/java/four/credits/podcatch/data/InternetPodcastRepository.kt
+++ b/app/src/main/java/four/credits/podcatch/data/InternetPodcastRepository.kt
@@ -1,8 +1,8 @@
 package four.credits.podcatch.data
 
-import four.credits.podcatch.data.persistence.PodcastDao
-import four.credits.podcatch.data.persistence.toDatabaseModel
-import four.credits.podcatch.data.persistence.toDomainModel
+import four.credits.podcatch.data.persistence.podcasts.PodcastDao
+import four.credits.podcatch.data.persistence.podcasts.toDatabaseModel
+import four.credits.podcatch.data.persistence.podcasts.toDomainModel
 import four.credits.podcatch.domain.Podcast
 import four.credits.podcatch.domain.PodcastRepository
 import kotlinx.coroutines.Dispatchers

--- a/app/src/main/java/four/credits/podcatch/data/PodcastParsing.kt
+++ b/app/src/main/java/four/credits/podcatch/data/PodcastParsing.kt
@@ -73,7 +73,7 @@ fun XmlPullParser.readItem(): Episode = withinTag("item") {
         when (name) {
             "title" -> title = readContents()
             "description" -> description = readContents()
-            "link" -> link = readContents()
+            "enclosure" -> link = readEnclosure()
             else -> skip()
         }
     }
@@ -82,6 +82,13 @@ fun XmlPullParser.readItem(): Episode = withinTag("item") {
     else throw ParseError(
         "one or more parameters are null: ($title, $description, $link)"
     )
+}
+
+fun XmlPullParser.readEnclosure(): String = withinTag("enclosure") {
+    val url = getAttributeValue(null, "url")
+    val type = getAttributeValue(null, "type")
+    if (type == "audio/mpeg") url.apply { this@readEnclosure.nextTag() }
+    else throw ParseError("only mp3 is supported")
 }
 
 // read the contents of a tag with name `tag` under the cursor

--- a/app/src/main/java/four/credits/podcatch/data/PodcastParsing.kt
+++ b/app/src/main/java/four/credits/podcatch/data/PodcastParsing.kt
@@ -1,6 +1,7 @@
 package four.credits.podcatch.data
 
 import android.util.Xml
+import four.credits.podcatch.domain.Episode
 import four.credits.podcatch.domain.Podcast
 import org.xmlpull.v1.XmlPullParser
 import java.io.InputStream
@@ -42,7 +43,7 @@ fun <T> XmlPullParser.withinTag(tag: String, action: (XmlPullParser) -> T): T {
 fun XmlPullParser.readChannel(link: String) = withinTag("channel") {
     var title: String? = null
     var description: String? = null
-    val episodes = mutableListOf<Pair<String, String>>()
+    val episodes = mutableListOf<Episode>()
     while (next() != XmlPullParser.END_TAG) {
         if (eventType != XmlPullParser.START_TAG) {
             continue
@@ -53,7 +54,9 @@ fun XmlPullParser.readChannel(link: String) = withinTag("channel") {
             else -> skip()
         }
     }
-    if (title != null && description != null) Podcast(title, description, link)
+    // TODO: populate episodes list
+    if (title != null && description != null)
+        Podcast(title, description, link, episodes)
     else throw ParseError(
         "one or more parameters are null: ($title, $description)"
     )

--- a/app/src/main/java/four/credits/podcatch/data/persistence/PodcastDatabase.kt
+++ b/app/src/main/java/four/credits/podcatch/data/persistence/PodcastDatabase.kt
@@ -1,9 +1,22 @@
 package four.credits.podcatch.data.persistence
 
+import androidx.room.AutoMigration
 import androidx.room.Database
 import androidx.room.RoomDatabase
+import four.credits.podcatch.data.persistence.episodes.Episode
+import four.credits.podcatch.data.persistence.episodes.EpisodeDao
+import four.credits.podcatch.data.persistence.podcasts.Podcast
+import four.credits.podcatch.data.persistence.podcasts.PodcastDao
 
-@Database(entities = [Podcast::class], version = 1)
+@Database(
+    entities = [Podcast::class, Episode::class],
+    version = 2,
+    autoMigrations = [
+        AutoMigration(from = 1, to = 2),
+    ]
+)
 abstract class PodcastDatabase : RoomDatabase() {
+    // TODO: rename podcast dao
     abstract val dao: PodcastDao
+    abstract val episodeDao: EpisodeDao
 }

--- a/app/src/main/java/four/credits/podcatch/data/persistence/PodcastDatabase.kt
+++ b/app/src/main/java/four/credits/podcatch/data/persistence/PodcastDatabase.kt
@@ -17,6 +17,6 @@ import four.credits.podcatch.data.persistence.podcasts.PodcastDao
 )
 abstract class PodcastDatabase : RoomDatabase() {
     // TODO: rename podcast dao
-    abstract val dao: PodcastDao
+    abstract val podcastDao: PodcastDao
     abstract val episodeDao: EpisodeDao
 }

--- a/app/src/main/java/four/credits/podcatch/data/persistence/PodcastDatabase.kt
+++ b/app/src/main/java/four/credits/podcatch/data/persistence/PodcastDatabase.kt
@@ -17,7 +17,6 @@ import four.credits.podcatch.data.persistence.podcasts.PodcastDao
     ]
 )
 abstract class PodcastDatabase : RoomDatabase() {
-    // TODO: rename podcast dao
     abstract val podcastDao: PodcastDao
     abstract val episodeDao: EpisodeDao
 }

--- a/app/src/main/java/four/credits/podcatch/data/persistence/PodcastDatabase.kt
+++ b/app/src/main/java/four/credits/podcatch/data/persistence/PodcastDatabase.kt
@@ -10,9 +10,10 @@ import four.credits.podcatch.data.persistence.podcasts.PodcastDao
 
 @Database(
     entities = [Podcast::class, Episode::class],
-    version = 2,
+    version = 3,
     autoMigrations = [
         AutoMigration(from = 1, to = 2),
+        AutoMigration(from = 2, to = 3),
     ]
 )
 abstract class PodcastDatabase : RoomDatabase() {

--- a/app/src/main/java/four/credits/podcatch/data/persistence/episodes/Episode.kt
+++ b/app/src/main/java/four/credits/podcatch/data/persistence/episodes/Episode.kt
@@ -1,0 +1,30 @@
+package four.credits.podcatch.data.persistence.episodes
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.ForeignKey
+import androidx.room.Index
+import androidx.room.PrimaryKey
+import four.credits.podcatch.data.persistence.podcasts.Podcast
+import four.credits.podcatch.domain.Episode as DomainEpisode
+
+@Entity(
+    foreignKeys = [ForeignKey(
+        entity = Podcast::class,
+        parentColumns = arrayOf("id"),
+        childColumns = arrayOf("podcastId"),
+        onDelete = ForeignKey.CASCADE
+    )],
+)
+data class Episode(
+    val title: String,
+    val description: String,
+    val link: String,
+    @ColumnInfo(index = true) val podcastId: Long,
+    @PrimaryKey(autoGenerate = true) val id: Long = 0
+) {
+    fun toDomainModel(): DomainEpisode =
+        DomainEpisode(title, description, link, id)
+}
+
+fun DomainEpisode.toDatabaseModel() = Episode(title, description, link, id)

--- a/app/src/main/java/four/credits/podcatch/data/persistence/episodes/Episode.kt
+++ b/app/src/main/java/four/credits/podcatch/data/persistence/episodes/Episode.kt
@@ -13,7 +13,8 @@ import four.credits.podcatch.domain.Episode as DomainEpisode
         entity = Podcast::class,
         parentColumns = arrayOf("id"),
         childColumns = arrayOf("podcastId"),
-        onDelete = ForeignKey.CASCADE
+        onDelete = ForeignKey.CASCADE,
+        onUpdate = ForeignKey.CASCADE,
     )],
 )
 data class Episode(

--- a/app/src/main/java/four/credits/podcatch/data/persistence/episodes/EpisodeDao.kt
+++ b/app/src/main/java/four/credits/podcatch/data/persistence/episodes/EpisodeDao.kt
@@ -9,6 +9,9 @@ import kotlinx.coroutines.flow.Flow
 @Dao
 interface EpisodeDao {
     @Upsert
+    suspend fun upsertEpisode(episode: List<Episode>)
+
+    @Upsert
     suspend fun upsertEpisode(episode: Episode)
 
     @Delete

--- a/app/src/main/java/four/credits/podcatch/data/persistence/episodes/EpisodeDao.kt
+++ b/app/src/main/java/four/credits/podcatch/data/persistence/episodes/EpisodeDao.kt
@@ -1,0 +1,19 @@
+package four.credits.podcatch.data.persistence.episodes
+
+import androidx.room.Dao
+import androidx.room.Delete
+import androidx.room.Query
+import androidx.room.Upsert
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface EpisodeDao {
+    @Upsert
+    suspend fun upsertEpisode(episode: Episode)
+
+    @Delete
+    suspend fun deleteEpisode(episode: Episode)
+
+    @Query("SELECT * FROM episode WHERE podcastId = :podcastId")
+    fun getEpisodesByPodcastId(podcastId: Long): Flow<List<Episode>>
+}

--- a/app/src/main/java/four/credits/podcatch/data/persistence/podcasts/Podcast.kt
+++ b/app/src/main/java/four/credits/podcatch/data/persistence/podcasts/Podcast.kt
@@ -1,4 +1,4 @@
-package four.credits.podcatch.data.persistence
+package four.credits.podcatch.data.persistence.podcasts
 
 import androidx.room.Entity
 import androidx.room.PrimaryKey

--- a/app/src/main/java/four/credits/podcatch/data/persistence/podcasts/Podcast.kt
+++ b/app/src/main/java/four/credits/podcatch/data/persistence/podcasts/Podcast.kt
@@ -14,7 +14,14 @@ data class Podcast(
     val link: String,
 )
 
-fun Podcast.toDomainModel() = DomainPodcast(title, description, link, id)
+// TODO: make way of passing proper episodes
+fun Podcast.toDomainModel() = DomainPodcast(
+    title,
+    description,
+    link,
+    episodes = listOf(),
+    id
+)
 
 fun DomainPodcast.toDatabaseModel(): Podcast =
     Podcast(id, title, description, link)

--- a/app/src/main/java/four/credits/podcatch/data/persistence/podcasts/Podcast.kt
+++ b/app/src/main/java/four/credits/podcatch/data/persistence/podcasts/Podcast.kt
@@ -3,6 +3,7 @@ package four.credits.podcatch.data.persistence.podcasts
 import androidx.room.Entity
 import androidx.room.PrimaryKey
 import four.credits.podcatch.domain.Podcast as DomainPodcast
+import four.credits.podcatch.domain.Episode as DomainEpisode
 
 @Entity
 data class Podcast(
@@ -14,14 +15,9 @@ data class Podcast(
     val link: String,
 )
 
-// TODO: make way of passing proper episodes
-fun Podcast.toDomainModel() = DomainPodcast(
-    title,
-    description,
-    link,
-    episodes = listOf(),
-    id
-)
+fun Podcast.toDomainModel(
+    episodes: List<DomainEpisode> = listOf()
+) = DomainPodcast(title, description, link, episodes, id)
 
 fun DomainPodcast.toDatabaseModel(): Podcast =
     Podcast(id, title, description, link)

--- a/app/src/main/java/four/credits/podcatch/data/persistence/podcasts/PodcastDao.kt
+++ b/app/src/main/java/four/credits/podcatch/data/persistence/podcasts/PodcastDao.kt
@@ -1,4 +1,4 @@
-package four.credits.podcatch.data.persistence
+package four.credits.podcatch.data.persistence.podcasts
 
 import androidx.room.Dao
 import androidx.room.Delete

--- a/app/src/main/java/four/credits/podcatch/data/persistence/podcasts/PodcastDao.kt
+++ b/app/src/main/java/four/credits/podcatch/data/persistence/podcasts/PodcastDao.kt
@@ -2,12 +2,16 @@ package four.credits.podcatch.data.persistence.podcasts
 
 import androidx.room.Dao
 import androidx.room.Delete
+import androidx.room.Insert
 import androidx.room.Query
 import androidx.room.Upsert
 import kotlinx.coroutines.flow.Flow
 
 @Dao
 interface PodcastDao {
+    @Insert
+    suspend fun insertPodcast(podcast: Podcast): Long
+
     @Upsert
     suspend fun upsertPodcast(podcast: Podcast)
 

--- a/app/src/main/java/four/credits/podcatch/domain/Episode.kt
+++ b/app/src/main/java/four/credits/podcatch/domain/Episode.kt
@@ -1,0 +1,8 @@
+package four.credits.podcatch.domain
+
+data class Episode(
+    val title: String,
+    val description: String,
+    val link: String,
+    val id: Long = 0
+)

--- a/app/src/main/java/four/credits/podcatch/domain/Podcast.kt
+++ b/app/src/main/java/four/credits/podcatch/domain/Podcast.kt
@@ -4,5 +4,6 @@ data class Podcast(
     val title: String,
     val description: String,
     val link: String,
+    val episodes: List<Episode>,
     val id: Long = 0,
 )

--- a/app/src/main/java/four/credits/podcatch/presentation/screens/add_podcast/AddPodcastScreen.kt
+++ b/app/src/main/java/four/credits/podcatch/presentation/screens/add_podcast/AddPodcastScreen.kt
@@ -115,7 +115,10 @@ private fun AddPodcastPreview() {
             Result.Loaded(Podcast(
                 "My Podcast",
                 "A podcast where I talk about me",
-                "https://example.com/podcast"
+                "https://example.com/podcast",
+                // TODO: you should possibly be able to see a details screen for
+                //  a podcast you haven't necessarily saved
+                listOf(),
             )),
             {},
             onClear = { text = "" },

--- a/app/src/main/java/four/credits/podcatch/presentation/screens/add_podcast/AddPodcastViewModel.kt
+++ b/app/src/main/java/four/credits/podcatch/presentation/screens/add_podcast/AddPodcastViewModel.kt
@@ -23,6 +23,7 @@ class AddPodcastViewModel(
     val result: StateFlow<Result> = _result
 
     fun searchUrl() {
+        if (url.value.isBlank()) return
         _result.update { Result.Loading }
         viewModelScope.launch {
             _result.update {

--- a/app/src/main/java/four/credits/podcatch/presentation/screens/add_podcast/AddPodcastViewModel.kt
+++ b/app/src/main/java/four/credits/podcatch/presentation/screens/add_podcast/AddPodcastViewModel.kt
@@ -17,7 +17,7 @@ import kotlinx.coroutines.launch
 class AddPodcastViewModel(
     private val podcastRepository: PodcastRepository
 ): ViewModel() {
-    val _url = MutableStateFlow("")
+    private val _url = MutableStateFlow("")
     val url: StateFlow<String> = _url
     private val _result = MutableStateFlow<Result>(Result.Nothing)
     val result: StateFlow<Result> = _result

--- a/app/src/main/java/four/credits/podcatch/presentation/screens/podcast_details/PodcastDetailsScreen.kt
+++ b/app/src/main/java/four/credits/podcatch/presentation/screens/podcast_details/PodcastDetailsScreen.kt
@@ -1,9 +1,10 @@
 package four.credits.podcatch.presentation.screens.podcast_details
 
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material3.Card
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -16,6 +17,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.sp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import four.credits.podcatch.R
+import four.credits.podcatch.domain.Episode
 import four.credits.podcatch.domain.Podcast
 import four.credits.podcatch.presentation.theme.AppIcons
 import four.credits.podcatch.presentation.theme.PodcatchTheme
@@ -37,15 +39,30 @@ private fun PodcastDetailsScreenInternal(
     podcast: Podcast,
     onDelete: () -> Unit,
 ) {
-    Column {
+    LazyColumn {
         // TODO: don't hardcode font sizes
-        Text(podcast.title, fontSize = 24.sp)
-        HorizontalDivider()
-        Text(podcast.description)
-        Box(modifier = Modifier.weight(1f))
-        IconButton(onClick = onDelete) {
-            Icon(AppIcons.Delete, stringResource(R.string.alt_delete_podcast))
+        item {
+            Text(podcast.title, fontSize = 24.sp)
+            HorizontalDivider()
+            Text(podcast.description)
         }
+        items(items = podcast.episodes, key = { it.id }) {
+            EpisodeDisplay(episode = it, modifier = Modifier.fillMaxWidth())
+        }
+        item {
+            IconButton(onClick = onDelete) {
+                Icon(AppIcons.Delete, stringResource(R.string.alt_delete_podcast))
+            }
+        }
+    }
+}
+
+@Composable
+private fun EpisodeDisplay(episode: Episode, modifier: Modifier = Modifier) {
+    Card {
+        Text(episode.title, fontSize = 16.sp)
+        HorizontalDivider()
+        Text(episode.description)
     }
 }
 

--- a/app/src/main/java/four/credits/podcatch/presentation/screens/podcast_details/PodcastDetailsScreen.kt
+++ b/app/src/main/java/four/credits/podcatch/presentation/screens/podcast_details/PodcastDetailsScreen.kt
@@ -1,7 +1,6 @@
 package four.credits.podcatch.presentation.screens.podcast_details
 
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.filled.Delete
@@ -12,7 +11,6 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.sp
@@ -51,7 +49,7 @@ private fun PodcastDetailsScreenInternal(
             Text(podcast.description)
         }
         items(items = podcast.episodes, key = { it.id }) {
-            EpisodeDisplay(episode = it, modifier = Modifier.fillMaxWidth())
+            EpisodeDisplay(episode = it)
         }
         item {
             IconButton(onClick = onDelete) {
@@ -62,7 +60,7 @@ private fun PodcastDetailsScreenInternal(
 }
 
 @Composable
-private fun EpisodeDisplay(episode: Episode, modifier: Modifier = Modifier) {
+private fun EpisodeDisplay(episode: Episode) {
     Card {
         Text(episode.title, fontSize = 16.sp)
         HorizontalDivider()
@@ -82,7 +80,7 @@ private fun PodcastDetailsScreenPreview() {
                 // TODO: implement displaying podcasts
                 listOf(),
             ),
-            {},
+            onDelete = {},
         )
     }
 }

--- a/app/src/main/java/four/credits/podcatch/presentation/screens/podcast_details/PodcastDetailsScreen.kt
+++ b/app/src/main/java/four/credits/podcatch/presentation/screens/podcast_details/PodcastDetailsScreen.kt
@@ -68,7 +68,7 @@ private fun EpisodeDisplay(episode: Episode) {
     }
 }
 
-@Preview
+@Preview(showBackground = true)
 @Composable
 private fun PodcastDetailsScreenPreview() {
     PodcatchTheme {
@@ -77,8 +77,20 @@ private fun PodcastDetailsScreenPreview() {
                 title = "My very important podcast",
                 description = "A podcast about android development",
                 link = "This shouldn't be visible",
-                // TODO: implement displaying podcasts
-                listOf(),
+                episodes = listOf(
+                    Episode(
+                        title = "Episode 1",
+                        description = "A cool description",
+                        link = "",
+                        id = 1,
+                    ),
+                    Episode(
+                        title = "Episode 2",
+                        description = "A cool description",
+                        link = "",
+                        id = 2,
+                    )
+                ),
             ),
             onDelete = {},
         )

--- a/app/src/main/java/four/credits/podcatch/presentation/screens/podcast_details/PodcastDetailsScreen.kt
+++ b/app/src/main/java/four/credits/podcatch/presentation/screens/podcast_details/PodcastDetailsScreen.kt
@@ -57,7 +57,9 @@ private fun PodcastDetailsScreenPreview() {
             Podcast(
                 title = "My very important podcast",
                 description = "A podcast about android development",
-                link = "This shouldn't be visible"
+                link = "This shouldn't be visible",
+                // TODO: implement displaying podcasts
+                listOf(),
             ),
             {},
         )

--- a/app/src/main/java/four/credits/podcatch/presentation/screens/podcast_details/PodcastDetailsScreen.kt
+++ b/app/src/main/java/four/credits/podcatch/presentation/screens/podcast_details/PodcastDetailsScreen.kt
@@ -1,5 +1,6 @@
 package four.credits.podcatch.presentation.screens.podcast_details
 
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -20,6 +21,7 @@ import four.credits.podcatch.R
 import four.credits.podcatch.domain.Episode
 import four.credits.podcatch.domain.Podcast
 import four.credits.podcatch.presentation.theme.AppIcons
+import four.credits.podcatch.presentation.theme.LocalSpacing
 import four.credits.podcatch.presentation.theme.PodcatchTheme
 
 @Composable
@@ -39,7 +41,9 @@ private fun PodcastDetailsScreenInternal(
     podcast: Podcast,
     onDelete: () -> Unit,
 ) {
-    LazyColumn {
+    LazyColumn(
+        verticalArrangement = Arrangement.spacedBy(LocalSpacing.current.medium)
+    ) {
         // TODO: don't hardcode font sizes
         item {
             Text(podcast.title, fontSize = 24.sp)

--- a/app/src/main/java/four/credits/podcatch/presentation/screens/podcast_details/PodcastDetailsViewModel.kt
+++ b/app/src/main/java/four/credits/podcatch/presentation/screens/podcast_details/PodcastDetailsViewModel.kt
@@ -45,6 +45,7 @@ class PodcastDetailsViewModel(
             "loading...",
             "loading...",
             "loading...",
+            listOf(),
         )
 
         const val PODCAST_ID_ARG = "podcastId"

--- a/app/src/main/java/four/credits/podcatch/presentation/screens/view_podcasts/ViewPodcastsScreen.kt
+++ b/app/src/main/java/four/credits/podcatch/presentation/screens/view_podcasts/ViewPodcastsScreen.kt
@@ -94,9 +94,24 @@ private fun AddPodcastFloatingActionButton(onAddPodcastPressed: () -> Unit) {
 @Composable
 private fun ViewPodcastsScreenPreview() {
     val podcasts = listOf(
-        Podcast("Podcast 1", "A podcast about movies", link = ""),
-        Podcast("Podcast 2", "A podcast about music", link = ""),
-        Podcast("Podcast 3", "A podcast about coding", link = ""),
+        Podcast(
+            "Podcast 1",
+            "A podcast about movies",
+            link = "",
+            episodes = listOf()
+        ),
+        Podcast(
+            "Podcast 2",
+            "A podcast about music",
+            link = "",
+            episodes = listOf()
+        ),
+        Podcast(
+            "Podcast 3",
+            "A podcast about coding",
+            link = "",
+            episodes = listOf()
+        ),
     )
     PodcatchTheme {
         ViewPodcastsScreenInner(podcasts, {}, {})

--- a/app/src/main/java/four/credits/podcatch/presentation/screens/view_podcasts/ViewPodcastsScreen.kt
+++ b/app/src/main/java/four/credits/podcatch/presentation/screens/view_podcasts/ViewPodcastsScreen.kt
@@ -89,7 +89,7 @@ private fun AddPodcastFloatingActionButton(onAddPodcastPressed: () -> Unit) {
     }
 }
 
-@Preview
+@Preview(showBackground = true)
 @Composable
 private fun ViewPodcastsScreenPreview() {
     val podcasts = listOf(
@@ -97,19 +97,22 @@ private fun ViewPodcastsScreenPreview() {
             "Podcast 1",
             "A podcast about movies",
             link = "",
-            episodes = listOf()
+            episodes = listOf(),
+            id = 1,
         ),
         Podcast(
             "Podcast 2",
             "A podcast about music",
             link = "",
-            episodes = listOf()
+            episodes = listOf(),
+            id = 2,
         ),
         Podcast(
             "Podcast 3",
             "A podcast about coding",
             link = "",
-            episodes = listOf()
+            episodes = listOf(),
+            id = 3
         ),
     )
     PodcatchTheme {

--- a/app/src/main/java/four/credits/podcatch/presentation/screens/view_podcasts/ViewPodcastsScreen.kt
+++ b/app/src/main/java/four/credits/podcatch/presentation/screens/view_podcasts/ViewPodcastsScreen.kt
@@ -58,8 +58,7 @@ private fun ViewPodcastsScreenInner(
                 LocalSpacing.current.medium
             )
         ) {
-            // TODO: is keying off title alright?
-            items(podcasts, key = { it.title }) {
+            items(podcasts, key = { it.id }) {
                 PodcastDisplay(podcast = it, onPressed = onPodcastPressed)
             }
         }


### PR DESCRIPTION
- **add episodes concept**
- **rename dao variables to podcastDao**
- **add list of episodes to domain podcasts**
- **test single channel feeds**
- **parse episodes from feed**
- **make a MutableStateFlow private**
- **don't search for podcast if url field is empty**
- **update todos**
- **start displaying episodes**
- **key off id, not title in view podcasts screen**
- **episode insertion doesn't break foreign keys**
- **put spacing between each episode on details screen**
- **tidy PodcastDetailsScreen**
- **fix previews**
- **update todos**
- **pass episodes to toDomainModel better**
